### PR TITLE
Got rid of list all buckets permission problem

### DIFF
--- a/s3plz/__init__.py
+++ b/s3plz/__init__.py
@@ -286,9 +286,7 @@ class S3:
             "Your supplied credentials were invalid!"
 
         # lookup bucket
-        for b in conn.get_all_buckets():
-            if self.bucket_name == b.name:
-                return b
+        return conn.get_bucket(self.bucket_name)
 
         # bucket doesn't exist.
         raise ValueError(


### PR DESCRIPTION
### Overview

This is a pretty simple fix. There exists a getter now in Boto so listing all the buckets to find the one you want isn't necessary. Removes the need to give List All Buckets permissions to everyone who wants to use s3plz for one bucket 
