### PR TITLE
Restore original defensiveness (as a feature)

### DIFF
--- a/s3plz/__init__.py
+++ b/s3plz/__init__.py
@@ -291,8 +291,8 @@ class S3:
         else:
             # bucket doesn't exist.
             raise ValueError(
-                'Bucket {} Does Not Exist!'\
-                .format(self.bucket_name))
+                'Bucket {} Does Not Exist Or Current Permissions ' +
+                'Cannot Access It!'.format(self.bucket_name))
 
     def _gen_key_from_fp(self, filepath, **kw):
         """

--- a/s3plz/__init__.py
+++ b/s3plz/__init__.py
@@ -286,12 +286,13 @@ class S3:
             "Your supplied credentials were invalid!"
 
         # lookup bucket
-        return conn.get_bucket(self.bucket_name)
-
-        # bucket doesn't exist.
-        raise ValueError(
-            'Bucket {} Does Not Exist!'\
-            .format(self.bucket_name))
+        if conn.lookup(self.bucket_name):
+            return conn.get_bucket(self.bucket_name)
+        else:
+            # bucket doesn't exist.
+            raise ValueError(
+                'Bucket {} Does Not Exist!'\
+                .format(self.bucket_name))
 
     def _gen_key_from_fp(self, filepath, **kw):
         """


### PR DESCRIPTION
_Previously_: https://github.com/enigma-io/s3plz/pull/12

On second though (and pass and review), this library is meant to be friendly and simple to use, which means it should be defensive and helpful when a bucket is not found. Let's put that back in.

The previous functionality of iterating through all buckets (which is a separate permission) has now been replaced with the `boto.s3.connection` `lookup()` function. This simply returns `None` when a bucket cannot be accessed instead of throwing a permissions error.
